### PR TITLE
Add string support for eth_signTypedData_v4

### DIFF
--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -331,6 +331,14 @@ Try using another mnemonic or deriving less keys.`,
 Please double check your calls' parameters and keep your Ethereum node up to date.`,
       shouldBeReported: false,
     },
+    ETHSIGN_TYPED_DATA_V4_INVALID_DATA_PARAM: {
+      number: 113,
+      message: 'Invalid "data" param when calling eth_signTypedData_v4.',
+      title: "Invalid `data` param when calling eth_signTypedData_v4.",
+      description: `You called \`eth_signTypedData_v4\` with incorrect parameters.
+Please check that you are sending a \`data\` parameter with as a JSON string or object conforming to EIP712 TypedData schema.`,
+      shouldBeReported: false,
+    },
   },
   TASK_DEFINITIONS: {
     PARAM_AFTER_VARIADIC: {

--- a/packages/hardhat-core/src/internal/core/providers/accounts.ts
+++ b/packages/hardhat-core/src/internal/core/providers/accounts.ts
@@ -87,11 +87,22 @@ export class LocalAccountsProvider extends ProviderWrapperWithChainId {
         throw new HardhatError(ERRORS.NETWORK.ETHSIGN_MISSING_DATA_PARAM);
       }
 
+      let typedMessage = data;
+      if (typeof data == "string") {
+        try {
+          typedMessage = JSON.parse(data);
+        } catch (error) {
+          throw new HardhatError(
+            ERRORS.NETWORK.ETHSIGN_TYPED_DATA_V4_INVALID_DATA_PARAM
+          );
+        }
+      }
+
       // if we don't manage the address, the method is forwarded
       const privateKey = this._getPrivateKeyForAddressOrNull(address);
       if (privateKey !== null) {
         return ethSigUtil.signTypedData_v4(privateKey, {
-          data,
+          data: typedMessage,
         });
       }
     }

--- a/packages/hardhat-core/test/internal/core/providers/accounts.ts
+++ b/packages/hardhat-core/test/internal/core/providers/accounts.ts
@@ -410,6 +410,81 @@ describe("Local accounts provider", () => {
       );
     });
 
+    it("Should be compatible with stringified JSON input", async () => {
+      const provider = new LocalAccountsProvider(mock, [
+        // keccak256("cow")
+        "0xc85ef7d79691fe79573b1a7064c19c1a9819ebdbd1faaab1a8ec92344438aaf4",
+      ]);
+
+      const result = await provider.request({
+        method: "eth_signTypedData_v4",
+        params: [
+          "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+          JSON.stringify({
+            types: {
+              EIP712Domain: [
+                { name: "name", type: "string" },
+                { name: "version", type: "string" },
+                { name: "chainId", type: "uint256" },
+                { name: "verifyingContract", type: "address" },
+              ],
+              Person: [
+                { name: "name", type: "string" },
+                { name: "wallet", type: "address" },
+              ],
+              Mail: [
+                { name: "from", type: "Person" },
+                { name: "to", type: "Person" },
+                { name: "contents", type: "string" },
+              ],
+            },
+            primaryType: "Mail",
+            domain: {
+              name: "Ether Mail",
+              version: "1",
+              chainId: 1,
+              verifyingContract: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+            },
+            message: {
+              from: {
+                name: "Cow",
+                wallet: "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+              },
+              to: {
+                name: "Bob",
+                wallet: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+              },
+              contents: "Hello, Bob!",
+            },
+          }),
+        ],
+      });
+
+      assert.equal(
+        result,
+        "0x4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d07299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b915621c"
+      );
+    });
+
+    it("Should throw if data string input is not JSON", async () => {
+      const provider = new LocalAccountsProvider(mock, [
+        // keccak256("cow")
+        "0xc85ef7d79691fe79573b1a7064c19c1a9819ebdbd1faaab1a8ec92344438aaf4",
+      ]);
+
+      await expectHardhatErrorAsync(
+        () =>
+          wrapper.request({
+            method: "eth_signTypedData_v4",
+            params: [
+              "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+              "}thisisnotvalidjson{",
+            ],
+          }),
+        ERRORS.NETWORK.ETHSIGN_TYPED_DATA_V4_INVALID_DATA_PARAM
+      );
+    });
+
     it("Should throw if no data is given", async () => {
       await expectHardhatErrorAsync(
         () =>


### PR DESCRIPTION
This should provide eth_signTypedData_v4 compatibility with ethers and other JSON RPC providers that are following Metamask's implementation.

See this comment on nlordell's PR to the base hardhat repo for the impetus for these changes:
https://github.com/nomiclabs/hardhat/pull/1346#issuecomment-826041105